### PR TITLE
Belastingdruk weer toegevoegd

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -3,11 +3,7 @@ require("@rushstack/eslint-patch/modern-module-resolution");
 
 module.exports = {
   root: true,
-  extends: [
-    "plugin:vue/vue3-essential",
-    "eslint:recommended",
-    "@vue/eslint-config-prettier",
-  ],
+  extends: ["plugin:vue/vue3-essential", "eslint:recommended", "@vue/eslint-config-prettier"],
   parserOptions: {
     ecmaVersion: "latest",
   },

--- a/src/components/HoofdPanel.vue
+++ b/src/components/HoofdPanel.vue
@@ -49,13 +49,11 @@
           <div id="md"></div>
         </n-space>
       </n-tab-pane>
-      <!--
-      <n-tab-pane name="eb" tab="Effectieve Belasting" key="eb">
+      <n-tab-pane name="bd" tab="Belastingdruk" key="bd">
         <n-space vertical>
-          <div id="eb"></div>
+          <div id="bd"></div>
         </n-space>
       </n-tab-pane>
--->
     </n-tabs>
     <n-scrollbar id="legenda" v-if="gegevens.tab != 'intro'">
       <Legenda :data="legendaData" />

--- a/src/components/IntroBluemink.vue
+++ b/src/components/IntroBluemink.vue
@@ -21,10 +21,10 @@
         Als de marginale druk hoog is, dan zal minder werken bij een salarisverhoging niet direct tot veel minder
         inkomen zorgen.
       </dd>
-      <dt><b>Effectieve Belasting</b></dt>
+      <dt><b>Belastingdruk</b></dt>
       <dd>
         Dit geeft weer hoeveel procent belasting betaald moet worden na verrekening van kortingen. Het gaat om bruto
-        belasting waar kortingen vanaf zijn getrokken. Dit zijn arbeidskorting, algemene heffings korting,
+        belasting waar kortingen vanaf zijn getrokken. Dit zijn arbeidskorting, algemene heffingskorting,
         inkomensafhankelijke combinatie korting. In deze berekening zijn toeslagen niet meegenomen omdat een toeslag een
         bijdrage is van een andere uitgave. De effecten van een toelage hangen dus af van uitgaven waarvoor de toeslag
         wordt uitgekeerd. Dit is dus niet direct te koppelen aan de effectief te betalen belasting.

--- a/src/components/IntroPagina.vue
+++ b/src/components/IntroPagina.vue
@@ -18,19 +18,14 @@
         Als de marginale druk hoog is, dan zal minder werken bij een salarisverhoging niet direct tot veel minder
         inkomen zorgen.
       </dd>
-      <!--
-      <dt><b>Effectieve Belasting</b></dt>
+      <dt><b>Belastingdruk</b></dt>
       <dd>
-        Dit geeft weer hoeveel procent belasting betaald moet worden na
-        verrekening van kortingen. Het gaat om bruto belasting waar kortingen
-        vanaf zijn getrokken. Dit zijn arbeidskorting, algemene heffingskorting,
-        inkomensafhankelijke combinatie korting. In deze berekening
-        zijn toeslagen niet meegenomen omdat een toeslag een bijdrage is van een
-        andere uitgave. De effecten van een toelage hangen dus af van uitgaven
-        waarvoor de toeslag wordt uitgekeerd. Dit is dus niet direct te koppelen
-        aan de effectief te betalen belasting.
+        Dit geeft weer hoeveel procent belasting betaald moet worden na verrekening van kortingen. Het gaat om bruto
+        belasting waar kortingen vanaf zijn getrokken. Dit zijn arbeidskorting, algemene heffingskorting,
+        inkomensafhankelijke combinatie korting. In deze berekening zijn toeslagen niet meegenomen omdat een toeslag een
+        bijdrage is van een andere uitgave. De effecten van een toelage hangen dus af van uitgaven waarvoor de toeslag
+        wordt uitgekeerd. Dit is dus niet direct te koppelen aan de effectief te betalen belasting.
       </dd>
--->
     </dl>
   </n-space>
 </template>

--- a/src/js/berekeningen/Belastingdruk.js
+++ b/src/js/berekeningen/Belastingdruk.js
@@ -15,18 +15,18 @@
  * along with this program.  If not, see http://www.gnu.org/licenses/.
  */
 import { BeschikbaarInkomen } from "@/js/berekeningen/BeschikbaarInkomen";
-import { EffectieveBelastingLegenda } from "@/js/grafieken/EffectieveBelastingLegenda";
+import { BelastingdrukLegenda } from "@/js/grafieken/BelastingdrukLegenda";
 
 /**
  * Berekend het belastingbedrag na verrekening van alle kortingen en toeslagen.
  */
-export class EffectieveBelasting extends BeschikbaarInkomen {
+export class Belastingdruk extends BeschikbaarInkomen {
   constructor(vis, personen, wonen) {
     super(vis, personen, wonen);
   }
 
   createLegenda() {
-    return new EffectieveBelastingLegenda(this);
+    return new BelastingdrukLegenda(this);
   }
 
   getYDomain() {
@@ -44,21 +44,21 @@ export class EffectieveBelasting extends BeschikbaarInkomen {
       beschikbaarInkomen.algemeneHeffingsKorting +
       beschikbaarInkomen.arbeidskorting +
       beschikbaarInkomen.inkomensafhankelijkeCombinatiekorting;
-    const effectieveBelasting = Math.max(0, arbeidsInkomen - totaal);
+    const belastingdruk = Math.max(0, arbeidsInkomen - totaal);
 
     return {
       arbeidsInkomen: arbeidsInkomen,
       brutoInkomstenBelasting: beschikbaarInkomen.brutoInkomstenBelasting,
-      effectieveBelasting: effectieveBelasting,
-      effectieveBelastingPercentage: 100 * (effectieveBelasting / arbeidsInkomen),
+      belastingdruk: belastingdruk,
+      belastingdrukPercentage: 100 * (belastingdruk / arbeidsInkomen),
     };
   }
 
   verzamelGrafiekSeries(alles, beschikbaarInkomen, id) {
     alles.push({
       id: id,
-      type: "effectieve belasting",
-      getal: this.afronden(beschikbaarInkomen.effectieveBelastingPercentage, this.getFactor()),
+      type: "Belastingdruk",
+      getal: this.afronden(beschikbaarInkomen.belastingdrukPercentage, this.getFactor()),
     });
   }
 }

--- a/src/js/berekeningen/BeschikbaarInkomen.ts
+++ b/src/js/berekeningen/BeschikbaarInkomen.ts
@@ -28,7 +28,6 @@ import {
   LeeftijdType,
   PersoonType,
   WonenType,
-  WoningType,
 } from "../../types";
 import { Legenda } from "../grafieken/Legenda";
 

--- a/src/js/berekeningen/algemeen.ts
+++ b/src/js/berekeningen/algemeen.ts
@@ -17,13 +17,24 @@
 import { Berekenen } from "./Berekenen";
 import { BeschikbaarInkomen } from "./BeschikbaarInkomen";
 import { MarginaleDruk } from "./MarginaleDruk";
-import { EffectieveBelasting } from "./EffectieveBelasting";
+import { Belastingdruk } from "./Belastingdruk";
 import { BlueminkBeschikbaarInkomen } from "../../bluemink/BlueminkBeschikbaarInkomen";
-import { GrafiekType, LeeftijdType, PeriodeType, PersoonType, TabType, WonenType, WoningType } from "../../types";
+import {
+  GrafiekType,
+  PersoonType,
+  TabType,
+  WonenType
+} from "../../types";
 
 const stap: number = 100;
 
-function berekenGrafiekData(path: string, type: TabType, vis: GrafiekType, personen: PersoonType[], wonen: WoningType) {
+function berekenGrafiekData(
+  path: string,
+  type: TabType,
+  vis: GrafiekType,
+  personen: PersoonType[],
+  wonen: WonenType
+) {
   let berekenen: Berekenen = null;
   let bi =
     path == "/bluemink"
@@ -37,8 +48,8 @@ function berekenGrafiekData(path: string, type: TabType, vis: GrafiekType, perso
     case TabType.MD:
       berekenen = new MarginaleDruk(vis, personen, wonen, bi);
       break;
-    case TabType.EB:
-      berekenen = new EffectieveBelasting(vis, personen, wonen, bi);
+    case TabType.BD:
+      berekenen = new Belastingdruk(vis, personen, wonen, bi);
       break;
   }
   let series = [];

--- a/src/js/berekeningen/gegevens.ts
+++ b/src/js/berekeningen/gegevens.ts
@@ -132,7 +132,8 @@ function grafiekNavigatieToJson(p: any): GrafiekType {
 
 function navigatieToJson(query: NavigatieType): InvoerGegevens {
   let basis: InvoerGegevens = {
-    tab: query.tab || "intro",
+    // Als oude code "eb" gebruikt is, vervang door nieuwe "bd".
+    tab: (query?.tab == "eb" ? "bd" : query?.tab) || "intro",
     personen: [defaultPersoon()],
     wonen: defaultWonen(),
     grafiek: defaultGrafiek(),

--- a/src/js/grafieken/BelastingdrukLegenda.js
+++ b/src/js/grafieken/BelastingdrukLegenda.js
@@ -18,9 +18,9 @@
 import { Legenda } from "@/js/grafieken/Legenda";
 
 /**
- * Legenda voor tonen effectieve belasting.
+ * Legenda voor tonen Belastingdruk.
  */
-export class EffectieveBelastingLegenda extends Legenda {
+export class BelastingdrukLegenda extends Legenda {
   constructor(berekenen) {
     super(berekenen);
   }
@@ -30,7 +30,7 @@ export class EffectieveBelastingLegenda extends Legenda {
     let b = this.berekenGetallen(data[offset]);
     let ld = {
       grafiek: [],
-      titel: "Effectieve belasting",
+      titel: "Belastingdruk",
       arbeidsInkomen: data[offset].id.toFixed(),
     };
 
@@ -52,6 +52,6 @@ export class EffectieveBelastingLegenda extends Legenda {
   }
 
   getLabelYAs() {
-    return "Effectieve belasting";
+    return "Belastingdruk";
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -90,7 +90,7 @@ export type MarginaleDrukResultaatType = {
 export enum TabType {
   BI = "bi",
   MD = "md",
-  EB = "eb",
+  BD = "bd",
 }
 
 export type PersoonNavigatieType = {


### PR DESCRIPTION
Was eerst effectieve belasting, maar belastingdruk is een betere benaming.